### PR TITLE
Change programming languages/libraries

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@
 ## 📝 Contents
 
 - [Bots](#-bots)
-- [Programming Languages](#-programming-libraries)
+- [API Libraries](#-api-libraries)
 - [Tools](#-tools)
 - [Modifications](#-modifications)
 - [Subreddits](#-popular-subreddits)
@@ -45,7 +45,7 @@
 - [lolbot](https://lolbot.lmao.tf) - Bot with lots of random fun features.
 
 
-## 💻 Programming Libraries
+## 💻 API Libraries
 **[Back To Top](#-contents)**
 - **Node.js**: [discord.js](https://github.com/discordjs/discord.js/); [discordie](https://github.com/qeled/discordie); [discord.io](https://github.com/izy521/discord.io/); [eris](https://github.com/abalabahaha/eris)  
 - **C#**: [Discord.Net](https://github.com/RogueException/Discord.Net); [DSharpPlus](https://github.com/NaamloosDT/DSharpPlus)  


### PR DESCRIPTION
You see calling "Programming Libraries" is not accurate to describe them instead "API wrapper" or "APi libraries" seems more accurate.
Furthermore, the README's table of content perhaps had a typo in it. [Reference](https://github.com/jacc/awesome-discord/compare/master...chroventer:master#diff-0730bb7c2e8f9ea2438b52e419dd86c9L17)

@jacc, what are your thoughts on it?