### PR TITLE
Remove lolbot from list of Discord Bots

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,6 @@
 - [AIRHORN SOLUTIONS](https://airhorn.solutions) - Airhorn soundboard.
 - [Septapus](https://septapus.com) - Bot that creates cartoons out of your server's chat messages.
 - [blargbot](https://blargbot.xyz) - Bot that allows you to create complex custom commands without coding knowledge.
-- [lolbot](https://lolbot.lmao.tf) - Bot with lots of random fun features.
 - [CaptchaBot](https://discordcaptcha.xyz) - Bot that focuses mainly on CAPTCHA Verification with multiple unique security-enhancing features.
 
 ## 💻 API Libraries


### PR DESCRIPTION
Going through this list, https://lolbot.lmao.tf no longer resolves to a website. I was not able to find the bot when searching for it via Google. I can only assume it's been taken down or relocated elsewhere.