### PR TITLE
feat: add DPP to C++ discord libraries

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,7 @@
 ## 💻 API Libraries
 **[Back To Top](#-contents)**
 - **C#**: [Discord.Net](https://github.com/RogueException/Discord.Net); [DSharpPlus](https://github.com/DSharpPlus/DSharpPlus)
-- **C++**: [aegis.cpp](https://github.com/zeroxs/aegis.cpp)
+- **C++**: [aegis.cpp](https://github.com/zeroxs/aegis.cpp); [DPP](https://github.com/brainboxdotcc/DPP)
 - **Node.js**: [discord.js](https://github.com/discordjs/discord.js); [discord.io](https://github.com/izy521/discord.io/); [eris](https://github.com/abalabahaha/eris)  
 - **TypeScript**: [typeit/discord](https://github.com/OwenCalvin/discord.ts)  
 - **Clojure**: [discljord](https://github.com/igjoshua/discljord)  


### PR DESCRIPTION
Added `DPP` to the list of C++ discord libraries.

P.S: aegis.cpp is discontinued, and they explicitly told that DPP is a better alternative.

![image](https://user-images.githubusercontent.com/60427892/142622205-45db3528-19cb-4b6b-899a-1e37357ac11d.png)
