### PR TITLE
Add Music Presence (musicpresence.app)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -160,6 +160,7 @@
 - [PreMiD](https://premid.app)
 - [Discord Apps Marketplace Rich Presence List](https://discordapps.dev/rpc)
 - [MultiRPC](https://github.com/FluxpointDev/MultiRPC) - Discord rich presence manager app for custom status with support for multiple profiles.
+- [Music Presence](https://musicpresence.app) - Share music from any media player in your Discord status
 
 ### Emoji
 - [DiscordFreeEmojis](https://github.com/An00nymushun/DiscordFreeEmojis)


### PR DESCRIPTION
Music Presence is the missing counterpart to your Spotify "Listening to" status.

It shares your listening activity from *any* media player on your device in your Discord status, with full metadata, an accurate playback position and an album cover 100% of the time. You have fine-grained control over which media players are shared in your status and you can always check the current state of your Discord status via the tray icon that changes dynamically.

There are [a lot more features](https://github.com/ungive/discord-music-presence/blob/master/documentation/roadmap.md) to come and the project had very good reception with users so far.

Future-proof URL: https://musicpresence.app
Repository: https://github.com/ungive/discord-music-presence
GitHub Organization: https://github.com/music-presence
Reddit post I made some time ago: https://www.reddit.com/r/TIdaL/comments/1d6azbm

The domain currently points to the GitHub repository, but will soon link to a real website for the project. You can verify that the domain is really owned by me (the maintainer of the project) by checking the "Verified" badge in the GitHub organization I linked to above (this badge only shows if the domain that is visible there is verified via DNS records).

You can find further links in the README of the project.

Would love to see my app added to your list! If you have any questions I am happy to answer them.

---

![banner](https://github.com/user-attachments/assets/efb9e418-3eed-42ec-b7db-850c0d9900db)