### PR TITLE
Remove inactive DiscordFreeEmojis link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -162,7 +162,6 @@
 - [MultiRPC](https://github.com/FluxpointDev/MultiRPC) - Discord rich presence manager app for custom status with support for multiple profiles.
 
 ### Emoji
-- [DiscordFreeEmojis](https://github.com/An00nymushun/DiscordFreeEmojis)
 - [ImageClipboard](https://imageclipboard.com/)
 - [emoji.gg](https://emoji.gg/)
 - [Emote Manager](https://github.com/joyn-gg/EmoteManager)


### PR DESCRIPTION
This removes `DiscordFreeEmojis` from the Emoji section because the project no longer appears maintained or useful for a curated list.

The linked repository is still reachable, but its latest code push was on 2024-07-24. This keeps the list focused on resources that are active and useful to readers.

The change is still a one-line removal and remains mergeable.
